### PR TITLE
Automatically add needs-triage label to all bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: A request for a new feature or an update to an existing feature
-labels: kind/enhancement
+labels: ["kind/enhancement", "needs-triage"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report something that's not working correctly
-labels: kind/bug
+labels: ["kind/bug", "needs-triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Add `needs-triage` label to issue templates. The goal for this is that we don't miss any new issues in our triage process. Right now, we may miss an issue from triage if

- It's files by a Pulumian (even, a customer engineer acting on behalf of a customer)
- A Pulumian responds to it with a comment (even if just asking for clarification)
- A label is applied

I think we should err of the safe side and mark all issues as needing triage. I realize that may be controversial and add even more triage work to the teams. If there is a way to apply this only to pulumi/pulumi and that's preferred - I'm happy to do so.